### PR TITLE
新規登録機能の修正

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -42,6 +42,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'apps.core',
+
+    'new_registration.register_user_id',
+    'new_registration.register_name', 
+    'new_registration.generate_user_id',
+    'new_registration.confirm_registration',
+    'new_registration.name_registration',
 ]
 
 MIDDLEWARE = [
@@ -59,7 +65,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, '..', 'frontend', 'templates'),],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -143,5 +149,6 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, '..','frontend', 'static'),
     os.path.join(BASE_DIR, 'apps', 'core', 'static'),
 ]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -17,7 +17,18 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+# 新規登録モジュールで使用
+from new_registration.generate_user_id.views import generate_user_id_main 
+from new_registration.register_name.views import register_name_main
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('apps.core.urls')),
+    #新規登録モジュールで使用
+    path('api/user-registration/', include('new_registration.register_user_id.urls')),
+    path('api/register-credentials/', include('new_registration.register_name.urls')),
+    path('api/generate-user-id/', include('new_registration.generate_user_id.urls')),
+    path('api/confirm-registration/', include('new_registration.confirm_registration.urls')),
+    path('api/name-registration/', include('new_registration.name_registration.urls')),
+
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         command: >
             /start.sh
         volumes:
-            - ./backend:/app
+            - .:/app
         ports:
             - "8000:8000"
         depends_on:

--- a/start.sh
+++ b/start.sh
@@ -5,8 +5,9 @@ set -e
 /wait-for-it.sh db:3306 --timeout=30 --strict -- echo "Database is up"
 
 # Django の起動
-python manage.py migrate
-python manage.py runserver 0.0.0.0:8000
+python /app/backend/manage.py migrate 
+python /app/backend/manage.py runserver 0.0.0.0:8000 
+
 
 # Node アプリの起動（必要なら）
 # cd frontend


### PR DESCRIPTION
変更したところで競合が起こりそうな所を共有します。

 １：フロントエンド参照場所の競合
フロントエンドフォルダを参照してくれないで、backend/app/core/templatesを参照している
これはconfig/setting.pyのTEMPLATESとSTATICFILES_DIRSで競合している。
変更内容
・TEMPLATES内のDIR[]に
os.path.join(BASE_DIR, '..', 'frontend', 'templates'),
を追加。
・STATICFILES_DIRSに
os.path.join(BASE_DIR, '..','frontend', 'static'),
を追加。
これでfrontendフォルダにあるhtmlファイルにアクセスするようにしている。backend/app/core/templates内のhtml等をfrontendフォルダ内のtemplatesに移動すれば問題なくなるはず…

２：user-infoデータベースへの接続
team04ユーザにuser-infoへアクセスする権限が渡されていないため、アクセス権限を追加した。
　変更内容
CREATE DATABASE IF NOT EXISTS user_info;
GRANT ALL PRIVILEGES ON user_info.* TO 'team04'@'%'; -- この行を追加
FLUSH PRIVILEGES; -- この行も追加 (権限変更をすぐに反映させるため)


３：docker-compose.ymlのweb volumeについて
backend/appの方に
 - ./backend:/app　から - .:/app　に変更した。
backendディレクトリだけではなく、team04ディレクトリ全体にアクセスできるようにするため。

４：start.shのDjangoの起動部分について
# Django の起動
python manage.py migrate
python manage.py runserver 0.0.0.0:8000
から
# Django の起動
python /app/backend/manage.py migrate 
python /app/backend/manage.py runserver 0.0.0.0:8000 
に変更した
manage.pyのパスを明示しているだけなので、競合は起きないはず…

